### PR TITLE
Change markdown-style link on website to hyperlink

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -256,7 +256,7 @@
         <div class="spoiler-body">
             <ul class="disc">
                 <li>Many QWERTY typists hardly use their right hand pinky, as the rare semicolon sits in its home row position and some type P with their ring finger.</li>
-                <li>These typists may need to build up their finger strength a little to type well on Colemak. Pinky fu! 🥋</li>
+                <li>These typists may need to build up their finger strength a little to type well on Colemak. Pinky fu! &thinsp;🥋</li>
                 <li>There are layouts that deprioritize the pinkies more than Colemak. These generally aren't so good, however.</li>
                 <li>There are even highly optimized layouts that have heavier pinky load than Colemak.</li>
                 <li>The <b>YOU</b> trigram in particular, isn't so great on Colemak. Trust us though: Most common n-grams are great.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,7 +218,7 @@
                 <li>Funnily enough, other layouts move lots of keys between hands and swap them around. Their learners don't complain.</li>
                 <li>Colemak, on the other hand, has this one somewhat hard-to-learn key swap, and lots of learners complain – since it's just that one?</li>
                 <li>If you make a change to Colemak that makes it worse, you're fixing a temporary problem with a permanently inferior solution!<br></li>
-                <li>In the [Colemak Design FAQ](https://colemak.com/Design_FAQ) Shai Coleman answers the R-S exchange question like this:
+                <li>In the <a href="https://colemak.com/Design_FAQ">Colemak Design FAQ</a> Shai Coleman answers the R-S exchange question like this:
                     <ul class="dashed">
                     <li>It significantly reduces same-finger. This is especially important as it affects the ring finger which is the least dexterous finger.</li>
                     <li>(e.g. try typing WSWSWS fast on QWERTY)</li>


### PR DESCRIPTION
Changes the link from appearing as `[Colemak Design FAQ](https://colemak.com/Design_FAQ)` to being a clickable hyperlink